### PR TITLE
Better support for installing different versions of Python

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,5 +6,7 @@ default['python3']['pip']['wheel_version'] = true
 default['python3']['pip']['virtualenv_version'] = true
 default['python3']['version'] = false
 default['python3']['name'] = 'python3'
+default['python3']['source'] = 'system'
+default['python3']['checksum'] = false
 default['python3']['pkg_options'] = false
 default['python3']['binary_name'] = 'python3'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,3 +7,4 @@ default['python3']['pip']['virtualenv_version'] = true
 default['python3']['version'] = false
 default['python3']['name'] = 'python3'
 default['python3']['pkg_options'] = false
+default['python3']['binary_name'] = 'python3'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -25,7 +25,16 @@ suites:
     run_list:
       - recipe[python3-test::default]
     attributes:
+  - name: python39
+    run_list:
+      - recipe[python3-test::default]
+    excludes:
+      - centos-7
+    attributes:
+      python3:
+        name: 'python39'
   - name: python3-pypy3
+
     run_list:
       - recipe[python3-test::default]
     attributes:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -7,7 +7,7 @@ module Python3
                python_system_path(resource)
              end
 
-      ::File.join(path, 'bin/python3')
+      ::File.join(path, 'bin', resource.binary_name)
     end
 
     def self.python_path(resource = new_resource)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,4 +4,4 @@
 #
 # Copyright:: 2022, The Authors, All Rights Reserved.
 
-python_install 'python3'
+python_install node['python3']['name']

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,10 +1,10 @@
 provides :python_install
 
-property :package_name, [String], default: lazy { node['python3']['name'] }
 property :version, [String, FalseClass], default: lazy { node['python3']['version'] }
-property :source, [String, nil], default: lazy { node['python3']['source'] }
-property :checksum, [String, nil], default: lazy { node['python3']['checksum'] }
+property :source, String, default: lazy { node['python3']['source'] }
+property :checksum, [String, FalseClass], default: lazy { node['python3']['checksum'] }
 property :pkg_options, [String, FalseClass], default: lazy { node['python3']['pkg_options'] }
+property :binary_name, String, default: lazy { node['python3']['binary_name'] }
 
 property :get_pip_url, String, default: lazy { node['python3']['pip']['url'] }
 property :get_pip_checksum, String, default: lazy { node['python3']['pip']['checksum'] }
@@ -20,10 +20,7 @@ load_current_value do |new_resource|
 
   if new_resource.source != 'portable_pypy3'
     pyversion = ::Mixlib::ShellOut.new("#{python_binary} --version").run_command.stdout.match('\s+(^[0-9\.]+)')&.last_match(1)
-    if new_resource.version
-      ::Chef::Log.warn("Found some version #{pyversion} -- vs #{new_resource.version}")
-      version pyversion
-    end
+    version pyversion if new_resource.version
   else
     version new_resource.version
   end
@@ -52,11 +49,11 @@ action :install do
       execute "tar -xjf #{pypy_archive} -C #{pypy_directory} --strip-components=1" do
         creates ::File.join(pypy_directory, 'bin/python3')
       end
-    elsif !new_resource.package_name.match(valid_name_regex)
-      ::Chef::Log.warn("Trying to install #{new_resource.package_name}. This does not look like a python3 package.")
+    elsif !new_resource.name.match(valid_name_regex)
+      ::Chef::Log.warn("Trying to install #{new_resource.name}. This does not look like a python3 package.")
       return
     else
-      package new_resource.package_name do
+      package new_resource.name do
         version new_resource.version if new_resource.version
         options new_resource.pkg_options if new_resource.pkg_options
       end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,7 +1,7 @@
 provides :python_install
 
 property :version, [String, FalseClass], default: lazy { node['python3']['version'] }
-property :source, String, default: lazy { node['python3']['source'] }
+property :source, [String, FalseClass], default: lazy { node['python3']['source'] }
 property :checksum, [String, FalseClass], default: lazy { node['python3']['checksum'] }
 property :pkg_options, [String, FalseClass], default: lazy { node['python3']['pkg_options'] }
 property :binary_name, String, default: lazy { node['python3']['binary_name'] }

--- a/resources/python_execute.rb
+++ b/resources/python_execute.rb
@@ -9,7 +9,7 @@ property :user, [String, Integer, NilClass]
 property :environment, Hash
 
 property :python_version, [String, FalseClass], default: lazy { node['python3']['version'] }
-property :python_provider, String, default: lazy { node['python3']['source'] }
+property :python_provider, [String, FalseClass], default: lazy { node['python3']['source'] }
 property :binary_name, String, default: lazy { node['python3']['binary_name'] }
 
 action :run do

--- a/resources/python_execute.rb
+++ b/resources/python_execute.rb
@@ -9,7 +9,8 @@ property :user, [String, Integer, NilClass]
 property :environment, Hash
 
 property :python_version, [String, FalseClass], default: lazy { node['python3']['version'] }
-property :python_provider, [String, nil], default: lazy { node['python3']['source'] }
+property :python_provider, String, default: lazy { node['python3']['source'] }
+property :binary_name, String, default: lazy { node['python3']['binary_name'] }
 
 action :run do
   execute new_resource.name do

--- a/resources/runtime.rb
+++ b/resources/runtime.rb
@@ -8,8 +8,9 @@ property :wheel_version, [String, TrueClass, FalseClass], default: true
 property :virtualenv_version, [String, TrueClass, FalseClass], default: true
 
 property :python_version, [String, FalseClass], default: lazy { node['python3']['version'] }
-property :python_provider, [String, nil], default: lazy { node['python3']['source'] }
-property :python_checksum, [String, nil], default: lazy { node['python3']['checksum'] }
+property :python_provider, String, default: lazy { node['python3']['source'] }
+property :python_checksum, [String, FalseClass], default: lazy { node['python3']['checksum'] }
+property :binary_name, String, default: lazy { node['python3']['binary_name'] }
 
 load_current_value do |new_resource|
   version = ::Python3.pip_version(new_resource)
@@ -24,7 +25,7 @@ end
 action :install do
   get_pip_location = ::File.join(::Chef::Config['cache_path'], 'get-pip.py')
 
-  python_install 'python3' do
+  python_install node['python3']['name'] do
     version new_resource.python_version
     source new_resource.python_provider
     checksum new_resource.python_checksum

--- a/resources/runtime.rb
+++ b/resources/runtime.rb
@@ -8,7 +8,7 @@ property :wheel_version, [String, TrueClass, FalseClass], default: true
 property :virtualenv_version, [String, TrueClass, FalseClass], default: true
 
 property :python_version, [String, FalseClass], default: lazy { node['python3']['version'] }
-property :python_provider, String, default: lazy { node['python3']['source'] }
+property :python_provider, [String, FalseClass], default: lazy { node['python3']['source'] }
 property :python_checksum, [String, FalseClass], default: lazy { node['python3']['checksum'] }
 property :binary_name, String, default: lazy { node['python3']['binary_name'] }
 

--- a/resources/virtualenv.rb
+++ b/resources/virtualenv.rb
@@ -7,8 +7,8 @@ property :user, [String, Integer, NilClass]
 property :pip_version, String
 
 property :python_version, [String, FalseClass], default: lazy { node['python3']['version'] }
-property :python_provider, [String, nil], default: lazy { node['python3']['source'] }
-property :python_checksum, [String, nil], default: lazy { node['python3']['checksum'] }
+property :python_provider, [String, FalseClass], default: lazy { node['python3']['source'] }
+property :python_checksum, [String, FalseClass], default: lazy { node['python3']['checksum'] }
 
 load_current_value do |new_resource|
   current_value_does_not_exist! unless ::File.exist?(::File.join(new_resource.virtualenv, 'bin/activate'))

--- a/resources/virtualenv.rb
+++ b/resources/virtualenv.rb
@@ -15,7 +15,7 @@ load_current_value do |new_resource|
 end
 
 action :create do
-  python_install 'python3' do
+  python_install node['python3']['name'] do
     version new_resource.python_version
     source new_resource.python_provider
     checksum new_resource.python_checksum

--- a/test/cookbooks/python3-test/recipes/default.rb
+++ b/test/cookbooks/python3-test/recipes/default.rb
@@ -4,7 +4,7 @@
 #
 # Copyright:: 2022, The Authors, All Rights Reserved.
 
-python_install 'python3'
+python_install node['python3']['name']
 
 python_package 'flask' do
   version '2.0.1'


### PR DESCRIPTION
* Remove some hardcoded values, python3 is not always the package name or the binary (could be python3.X)
* Update the test with a recipe that installs python3.9

Change-Id: I7fb81ef6d326987cddba26b5c685b62d98a6e132