### PR TITLE
Fix pip installation for python 3.6 and simplify virtualenv

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -50,10 +50,6 @@ module Python3
       ::File.join(pip_path(resource, system: false), 'bin', resource.pip_binary_name)
     end
 
-    def self.virtualenv_binary(resource = new_resource)
-      ::File.join(pip_path(resource, system: true), 'bin/virtualenv')
-    end
-
     def self.pypy_version(resource = new_resource)
       return resource.version if resource.respond_to?(:source) && resource.source == 'portable_pypy3'
       return resource.python_version if resource.respond_to?(:python_provider) && resource.python_provider == 'portable_pypy3'

--- a/resources/runtime.rb
+++ b/resources/runtime.rb
@@ -25,8 +25,6 @@ load_current_value do |new_resource|
 end
 
 action :install do
-  get_pip_location = ::File.join(::Chef::Config['cache_path'], 'get-pip.py')
-
   python_install new_resource.python_name do
     version new_resource.python_version
     source new_resource.python_provider
@@ -38,20 +36,11 @@ action :install do
   end
 
   converge_if_changed :pip_version do
-    directory ::Chef::Config['cache_path'] do
-      action :create
-      recursive true
+    execute 'ensure_pip' do
+      command "#{::Python3::Path.python_binary(new_resource)} -m ensurepip"
     end
-
-    remote_file 'get-pip.py' do
-      source new_resource.get_pip_url
-      checksum new_resource.get_pip_checksum
-      path get_pip_location
-      action :create
-    end
-
     execute 'install_pip' do
-      command "#{::Python3::Path.python_binary(new_resource)} #{get_pip_location} --upgrade --force-reinstall pip==#{new_resource.pip_version} --no-setuptools --no-wheel"
+      command "#{::Python3::Path.python_binary(new_resource)} -m pip install --upgrade --force-reinstall pip==#{new_resource.pip_version}"
     end
   end
 

--- a/resources/virtualenv.rb
+++ b/resources/virtualenv.rb
@@ -1,36 +1,25 @@
 provides :python_virtualenv
 
-property :virtualenv, String, name_property: true
-property :system_site_packages, equal_to: [true, false], default: false
+property :path, String, name_property: true
 property :group, [String, Integer, NilClass]
 property :user, [String, Integer, NilClass]
-property :pip_version, [String, TrueClass, FalseClass], default: lazy { node['python3']['pip']['version'] }
-property :pip_binary_name, [String, TrueClass, FalseClass], default: lazy { node['python3']['pip']['binary_name'] }
-
 property :python_version, [String, FalseClass], default: lazy { node['python3']['version'] }
 property :python_provider, [String, FalseClass], default: lazy { node['python3']['source'] }
-property :python_checksum, [String, FalseClass], default: lazy { node['python3']['checksum'] }
 property :binary_name, [String, FalseClass], default: lazy { node['python3']['binary_name'] }
+property :system_site_packages, [TrueClass, FalseClass], default: false
 
 load_current_value do |new_resource|
-  current_value_does_not_exist! unless ::File.exist?(::File.join(new_resource.virtualenv, 'bin/activate'))
+  current_value_does_not_exist! unless ::File.exist?(::File.join(new_resource.path, 'bin/activate'))
 end
 
 action :create do
-  python_install node['python3']['name'] do
-    version new_resource.python_version
-    source new_resource.python_provider
-    checksum new_resource.python_checksum
-  end
-
-  cmd = ::Python3::Path.virtualenv_binary(new_resource)
-  cmd += " --pip #{new_resource.pip_version}" if new_resource.pip_version
-  cmd += " --python #{new_resource.binary_name}" if new_resource.binary_name
-  cmd += " #{new_resource.virtualenv}"
+  cmd = "#{::Python3::Path.python_binary(new_resource)} -m venv"
+  cmd += ' --system-site-packages' if new_resource.system_site_packages
+  cmd += " #{new_resource.path}"
 
   execute cmd do
     user new_resource.user
     group new_resource.group
-    creates new_resource.virtualenv
+    creates new_resource.path
   end
 end

--- a/test/cookbooks/python3-test/recipes/default.rb
+++ b/test/cookbooks/python3-test/recipes/default.rb
@@ -18,7 +18,6 @@ node['python3_test']['pythons'].each_with_index do |python, idx|
 
   python_virtualenv "/opt/blah-#{idx}" do
     action :create
-    pip_binary_name python['pip_binary_name']
     binary_name python['binary_name']
   end
 


### PR DESCRIPTION
The previous installation was causing trouble with python -m venv.
The new way:
- uses ensurepip module to bootstrap the pip install
- uses the pip module (and not get-pip) to upgrade pip