### PR TITLE
Update validation regex

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -38,7 +38,7 @@ end
 
 action :install do
   converge_if_changed :version, :pip_version do
-    valid_name_regex = /^python3\.?\d?$/
+    valid_name_regex = /^python3\.?(\d+)?$/
     if new_resource.source == 'portable_pypy3'
       package 'bzip2'
 


### PR DESCRIPTION
* Python can have minor versions with two numbers
* The regex accepted 3.9 but not 3.11
