### PR TITLE
Improve pip installation in runtime resource

### DIFF
--- a/resources/runtime.rb
+++ b/resources/runtime.rb
@@ -36,12 +36,12 @@ action :install do
   end
 
   converge_if_changed :pip_version do
-    execute 'ensure_pip' do
-      command "#{::Python3::Path.python_binary(new_resource)} -m ensurepip"
-    end
-    execute 'install_pip' do
-      command "#{::Python3::Path.python_binary(new_resource)} -m pip install --upgrade --force-reinstall pip==#{new_resource.pip_version}"
-    end
+    # Install ensurepip if missing
+    execute "#{::Python3::Path.python_binary(new_resource)} -m ensurepip"
+    # Upgrade ensurepip
+    execute "#{::Python3::Path.python_binary(new_resource)} -m ensurepip --upgrade"
+    # Upgrade pip to desired version
+    execute "#{::Python3::Path.python_binary(new_resource)} -m pip install --upgrade --force-reinstall pip==#{new_resource.pip_version}"
   end
 
   converge_if_changed :setuptools_version do


### PR DESCRIPTION
Ensure pip is installed or upgraded using ensurepip before upgrading to the desired version. This guarantees pip is properly installed and up-to-date before attempting further upgrades.

This change addresses pip installation issues in Python 3.12 related to the deprecated pkgutil.ImpImporter.

See: https://stackoverflow.com/questions/77364550/attributeerror-module-pkgutil-has-no-attribute-impimporter-did-you-mean/77364602#77364602